### PR TITLE
Fix for default markdown target

### DIFF
--- a/R/nvim.interlace.R
+++ b/R/nvim.interlace.R
@@ -258,22 +258,26 @@ nvim.interlace.rmd <- function(Rmdfile, outform = NULL, rmddir, view = TRUE, ...
     on.exit(setwd(oldwd))
     setwd(rmddir)
 
-    if(outform == "odt"){
-        res <- rmarkdown::render(Rmdfile, "html_document", ...)
-        system(paste('soffice --invisible --convert-to odt', res))
-    } else {
-        res <- rmarkdown::render(Rmdfile, outform, ...)
-    }
+    if(!is.null(outform)){
+        if(outform == "odt"){
+            res <- rmarkdown::render(Rmdfile, "html_document", ...)
+            system(paste('soffice --invisible --convert-to odt', res))
+        } else {
+            res <- rmarkdown::render(Rmdfile, outform, ...)
+        }
 
-    if(view){
-        if(outform == "html_document")
-            browseURL(res)
-        else
-            if(outform == "pdf_document" || outform == "beamer_presentation")
-                OpenPDF(sub(".*/", "", res))
+        if(view){
+            if(outform == "html_document")
+                browseURL(res)
             else
-                if(outform == "odt")
-                    system(paste0("lowriter '", sub("\\.html$", ".odt'", res)))
+                if(outform == "pdf_document" || outform == "beamer_presentation")
+                    OpenPDF(sub(".*/", "", res))
+                else
+                    if(outform == "odt")
+                        system(paste0("lowriter '", sub("\\.html$", ".odt'", res)))
+        }
+    } else {
+        res <- rmarkdown::render(Rmdfile, ...)
     }
 }
 


### PR DESCRIPTION
If building the default (RMakeRmd("default")) which gets the target
directly from the YAML, then the variable outform will be NULL and that
breaks the tests in the if statements.  So just skip all the if
statements if outform is NULL